### PR TITLE
added option to only write out files that have unused dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,12 @@ Default value: true
 
 Removes detected unused dependencies and save the new files.
 
+#### saveFilesWithUnusedDependenciesOnly
+Type: boolean  
+Default value: false
+
+When removing unused dependencies (i.e. `removeUnusedDependencies: true`), only write out files that have unused dependencies.
+
 ### Usage Examples
 
 ```js

--- a/tasks/amdcheck.js
+++ b/tasks/amdcheck.js
@@ -48,7 +48,7 @@ module.exports = function(grunt) {
       logUnusedDependencyPaths: true,
       logUnusedDependencyNames: false,
       removeUnusedDependencies: true,
-      onlyFilesWithUnusedDependencies: false
+      saveFilesWithUnusedDependenciesOnly: false
     });
 
     options.logFilePath = options.logFilePath || options.logDependencyPaths || options.logDependencyNames || options.logUnusedDependencyPaths || options.logUnusedDependencyNames;
@@ -106,7 +106,7 @@ module.exports = function(grunt) {
         }
 
         if (options.removeUnusedDependencies) {
-          if (!options.onlyFilesWithUnusedDependencies || fileHasUnusedDependencies) {
+          if (!options.saveFilesWithUnusedDependenciesOnly || fileHasUnusedDependencies) {
             grunt.file.write(dest, processResult.optimizedContent);
           }
         }


### PR DESCRIPTION
In my workflow, when using the removeUnusedDependencies option, I only want to write out the files that have unused dependencies. This is because I use this plugin as more of a one-time or periodic check for unused dependencies, and when I find them, I want to remove them from the source files (instead of removing them each time I do a build). I do this by configuring this plugin to write the files to a temp directory and then copying the output files back over my source files. However, I don't want to overwrite any files that do not have unused dependencies, so I added an option to check for that before writing the files out.

By default, the option is set to false, so if you don't explicitly include it in your task configuration, the default behavior (write out all files) will be applied. To only write out files w/ unused dependencies, set `onlyFilesWithUnusedDependencies: true` as follows: 

```
              options: {
                // logUnusedDependencyNames: true,
                removeUnusedDependencies: true,
                excepts: ['module'],
                exceptsPaths: ['require', /^jquery\./],
                onlyFilesWithUnusedDependencies: true
              },

```

**NOTE:** I did not yet document this in `README.md`. If you want to merge this, I can do that. Also, I did not update `package.json` version info. 
