### PR TITLE
Add option for failing task in case of unused dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,12 @@ Default value: false
 
 When removing unused dependencies (i.e. `removeUnusedDependencies: true`), only write out files that have unused dependencies.
 
+#### failForUnusedDependency
+Type: boolean  
+Default value: false
+
+Lets the task fail when an unused dependency is found. Unused dependencies are not removed if enabled.
+
 ### Usage Examples
 
 ```js

--- a/tasks/amdcheck.js
+++ b/tasks/amdcheck.js
@@ -48,7 +48,8 @@ module.exports = function(grunt) {
       logUnusedDependencyPaths: true,
       logUnusedDependencyNames: false,
       removeUnusedDependencies: true,
-      saveFilesWithUnusedDependenciesOnly: false
+      saveFilesWithUnusedDependenciesOnly: false,
+      failForUnusedDependency: false
     });
 
     options.logFilePath = options.logFilePath || options.logDependencyPaths || options.logDependencyNames || options.logUnusedDependencyPaths || options.logUnusedDependencyNames;
@@ -98,6 +99,10 @@ module.exports = function(grunt) {
           }
 
           logResult(result);
+
+          if (options.failForUnusedDependency && result.unusedPaths.length) {
+            grunt.fail.warn('Unused paths: ' + result.unusedPaths.join(', ') + ' in ' + filepath);
+          }
         });
 
         if (fileHasUnusedDependencies) {


### PR DESCRIPTION
failForUnusedDependency lets the task fail with grunt.fail.warn, logging a message containing the unused path(s) and the file path. Defaults to false.